### PR TITLE
Add an error handler to the HEAD request

### DIFF
--- a/Assets/Plugins/WebGLCachedXMLHttpRequest/WebGLCachedXMLHttpRequest.jspre
+++ b/Assets/Plugins/WebGLCachedXMLHttpRequest/WebGLCachedXMLHttpRequest.jspre
@@ -39,6 +39,7 @@ function CachedXMLHttpRequest() {
 
   function revalidateCrossOriginRequest(meta, self, sendArguments) {
     var headXHR = new CachedXMLHttpRequest.XMLHttpRequest();
+    var onerror = xhr.onerror;
     headXHR.open("HEAD", meta.requestURL, cache.async);
     headXHR.onload = function() {
       cache.override = meta.lastModified ? meta.lastModified == headXHR.getResponseHeader("Last-Modified") : meta.eTag && meta.eTag == getETag(headXHR);
@@ -46,6 +47,11 @@ function CachedXMLHttpRequest() {
         return send.apply(self, sendArguments);
       loadComplete();
     };
+    headXHR.onerror = function(e) {
+			// if there is an error with the head request forward the request back 
+			// to the request that unity knows about. 
+			if (onerror) onerror(e);
+		}
     headXHR.send();
   }
 


### PR DESCRIPTION
If you have an asset bundle already in your cache and on your next
request anything goes wrong with the head request, the failed request
does not get back to unity. In our application it meant that our requests
would not be retried and would not present error information to the
user.

This simply forwards the error back to the original request made from
within unity.